### PR TITLE
Conflicts: Ignore KeyError

### DIFF
--- a/pcs-travelingsalesman.py
+++ b/pcs-travelingsalesman.py
@@ -21,7 +21,7 @@ OUTPUT_CSV = 'uist19a_travelingsalesman_order.csv'
 # Bidding CSVs from PCS: this is the only CSV that contains conflict information in PCS, so we use it.
 # This may be a list of CSVs if needed, since one of the ACs may be conflicted with a paper
 # and that one won't show up in their CSV. This just merges all the CSVs in the list.
-BIDDING_CSVS = ['uist19a_committee_bidding-msb.csv', 'uist19a_committee_bidding-reinecke.csv', 'uist19a_committee_bidding-andrewhead.csv']
+BIDDING_CSVS = ['uist19a_committee_bidding.csv']
 # Submission CSV: we use this as an index of all the papers and their current overall scores
 SUBMISSION_CSV = 'uist19a_submission.csv'
 
@@ -122,7 +122,8 @@ def split_into_groups(tsp_result, conflicts):
 def create_subgroup(subgroup, conflicts):
     group_conflicts = set()
     for subgroup_paper in subgroup:
-        group_conflicts.update(conflicts[subgroup_paper])
+        if subgroup_paper in conflicts:
+            group_conflicts.update(conflicts[subgroup_paper])
     return {
         'papers': subgroup,
         'conflicts': group_conflicts


### PR DESCRIPTION
When running this code, I saw a `KeyError` on the line:

```python
group_conflicts.update(conflicts[subgroup_paper])
```

which I imagine is because I had an incomplete set of conflicts when I tested with only my own personal conflicts CSV. Adding a check for the paper ID in the conflicts list seemed to fix it, and the program produces a sequence of papers where conflicts line up from one paper to the next.

This deal is probably not critical, but may make it more pleasant for a chair to test out initially before they add all the other chairs' conflicts.